### PR TITLE
Fixed missing parentheses in example comment

### DIFF
--- a/notebook2_arrays/py_exploratory_comp_2.ipynb
+++ b/notebook2_arrays/py_exploratory_comp_2.ipynb
@@ -238,7 +238,7 @@
     "alist[0] = 7  # Since alist is a list, you can change values \n",
     "print('modified alist', alist)\n",
     "#btuple[0] = 100  # Will give an error\n",
-    "#print 2*alist"
+    "#print(2*alist)"
    ]
   },
   {


### PR DESCRIPTION
Fixed missing parentheses in example comment