### PR TITLE
Fix: update domainname of notebook viewer

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,69 +67,69 @@ the one you want to open.
 
 <p> 
 Basics and Plotting &mdash;
-<a href="http://nbviewer.ipython.org/github/mbakker7/exploratory_computing_with_python/blob/master/notebook1_basics_plotting/py_exploratory_comp_1_sol.ipynb">Notebook 1</a>
+<a href="http://nbviewer.org/github/mbakker7/exploratory_computing_with_python/blob/master/notebook1_basics_plotting/py_exploratory_comp_1_sol.ipynb">Notebook 1</a>
  &mdash; <a href="https://youtube.com/watch?v=a505WqfH5Tg&si=EnSIkaIECMiOmarE">Video</a> 
 </p>
 
 <p>Arrays &mdash;
-<a href="http://nbviewer.ipython.org/github/mbakker7/exploratory_computing_with_python/blob/master/notebook2_arrays/py_exploratory_comp_2_sol.ipynb">Notebook 2</a> 
+<a href="http://nbviewer.org/github/mbakker7/exploratory_computing_with_python/blob/master/notebook2_arrays/py_exploratory_comp_2_sol.ipynb">Notebook 2</a> 
 &mdash; <a href="https://youtu.be/5RkeHZnZEnM">Video</a> 
 </p>
 
 <p>For loops and If/Else statements &mdash;
-<a href="http://nbviewer.ipython.org/github/mbakker7/exploratory_computing_with_python/blob/master/notebook3_for_and_if/py_exploratory_comp_3_sol.ipynb">Notebook 3</a> 
+<a href="http://nbviewer.org/github/mbakker7/exploratory_computing_with_python/blob/master/notebook3_for_and_if/py_exploratory_comp_3_sol.ipynb">Notebook 3</a> 
 &mdash; <a href="https://youtu.be/19gM-QEVugc">Video</a> 
 </p>
 
 <p>Functions &mdash;
-<a href="http://nbviewer.ipython.org/github/mbakker7/exploratory_computing_with_python/blob/master/notebook4_functions/py_exploratory_comp_4_sol.ipynb">Notebook 4</a> 
+<a href="http://nbviewer.org/github/mbakker7/exploratory_computing_with_python/blob/master/notebook4_functions/py_exploratory_comp_4_sol.ipynb">Notebook 4</a> 
 &mdash;  <a href="https://youtu.be/ZqjYNtWanMM">Video</a>
 </p>
 
 <p>Finding the Zeros of a Function &mdash;
-<a href="http://nbviewer.ipython.org/github/mbakker7/exploratory_computing_with_python/blob/master/notebook5_rootfinding/py_exploratory_comp_5_sol.ipynb">Notebook 5</a> 
+<a href="http://nbviewer.org/github/mbakker7/exploratory_computing_with_python/blob/master/notebook5_rootfinding/py_exploratory_comp_5_sol.ipynb">Notebook 5</a> 
 </p>
 
 <p>Systems of linear equations &mdash;
-<a href="http://nbviewer.ipython.org/github/mbakker7/exploratory_computing_with_python/blob/master/notebook6_linear_systems/py_exploratory_comp_6_sol.ipynb">Notebook 6</a> 
+<a href="http://nbviewer.org/github/mbakker7/exploratory_computing_with_python/blob/master/notebook6_linear_systems/py_exploratory_comp_6_sol.ipynb">Notebook 6</a> 
 </p>
 
 <p>Bugs &mdash;
-<a href="http://nbviewer.ipython.org/github/mbakker7/exploratory_computing_with_python/blob/master/notebook7_bugs/py_exploratory_comp_7_sol.ipynb">Notebook 7</a> 
+<a href="http://nbviewer.org/github/mbakker7/exploratory_computing_with_python/blob/master/notebook7_bugs/py_exploratory_comp_7_sol.ipynb">Notebook 7</a> 
 </p>
 
 <p>Pandas and Time Series &mdash;
-<a href="http://nbviewer.ipython.org/github/mbakker7/exploratory_computing_with_python/blob/master/notebook8_pandas/py_exploratory_comp_8_sol.ipynb">Notebook 8</a>
+<a href="http://nbviewer.org/github/mbakker7/exploratory_computing_with_python/blob/master/notebook8_pandas/py_exploratory_comp_8_sol.ipynb">Notebook 8</a>
 &mdash;  <a href="https://youtu.be/MTdIY6uFY6M">Video</a>
 </p>
 
 <p>Discrete Random Variables &mdash;
-<a href="http://nbviewer.ipython.org/github/mbakker7/exploratory_computing_with_python/blob/master/notebook9_discrete_random_variables/py_exploratory_comp_9_sol.ipynb">Notebook 9</a> 
+<a href="http://nbviewer.org/github/mbakker7/exploratory_computing_with_python/blob/master/notebook9_discrete_random_variables/py_exploratory_comp_9_sol.ipynb">Notebook 9</a> 
 &mdash;  <a href="https://youtu.be/iKBHWz-MHR8">Video</a>
 </p>
 
 <p>Continuous Random Variables &mdash;
-<a href="http://nbviewer.ipython.org/github/mbakker7/exploratory_computing_with_python/blob/master/notebook10_continuous_random_variables/py_exploratory_comp_10_sol.ipynb">Notebook 10</a> 
+<a href="http://nbviewer.org/github/mbakker7/exploratory_computing_with_python/blob/master/notebook10_continuous_random_variables/py_exploratory_comp_10_sol.ipynb">Notebook 10</a> 
 &mdash;  <a href="https://youtu.be/ThpusgXnMGI">Video</a>
 </p>
 
 <p>Distribution of the Mean and Hypothesis Tests Theorem &mdash;
-<a href="http://nbviewer.ipython.org/github/mbakker7/exploratory_computing_with_python/blob/master/notebook11_hypothesis_test/py_exploratory_comp_11_sol.ipynb">Notebook 11</a> 
+<a href="http://nbviewer.org/github/mbakker7/exploratory_computing_with_python/blob/master/notebook11_hypothesis_test/py_exploratory_comp_11_sol.ipynb">Notebook 11</a> 
 &mdash;  <a href="http://youtu.be/OaD_bN3eg8o">Video (Python 2)</a>
 </p>
 
 <p>Object oriented programming &mdash;
-<a href="http://nbviewer.ipython.org/github/mbakker7/exploratory_computing_with_python/blob/master/notebook12_oop/py_exploratory_comp_12_sol.ipynb">Notebook 12</a>
+<a href="http://nbviewer.org/github/mbakker7/exploratory_computing_with_python/blob/master/notebook12_oop/py_exploratory_comp_12_sol.ipynb">Notebook 12</a>
 &mdash;  <a href="https://youtu.be/pNLAEDbK03s">Video (Python 2)</a>
 </p>
 
 <p>Regression I &mdash;
-<a href="http://nbviewer.ipython.org/github/mbakker7/exploratory_computing_with_python/blob/master/notebook13_regression1/py_exploratory_comp_13_sol.ipynb">Notebook 13</a>
+<a href="http://nbviewer.org/github/mbakker7/exploratory_computing_with_python/blob/master/notebook13_regression1/py_exploratory_comp_13_sol.ipynb">Notebook 13</a>
 </p>
 
 <p> 
 Test Notebooks 1-4 &mdash;
-<a href="http://nbviewer.ipython.org/github/mbakker7/exploratory_computing_with_python/blob/master/notebook1-4_test/notebook1-4_test.ipynb">Test Notebook 1-4</a>
+<a href="http://nbviewer.org/github/mbakker7/exploratory_computing_with_python/blob/master/notebook1-4_test/notebook1-4_test.ipynb">Test Notebook 1-4</a>
 </p>
 
 <p> To be added soon: Regression II, ipywidgets, animations</p>


### PR DESCRIPTION
fixed issue #14

The links to the notebooks got stuck in a redirect loop. `nbviewer.ipython.org` redirects to `nbviewer.jupyter.org` which _sometimes_ (depending on browser and cookies) redirects to itself (= bad) or to  `nbviewer.org` (= good).

Fixed this by linking directly to `nbviewer.org`.